### PR TITLE
fix: wrong redirection when clicking log-out button

### DIFF
--- a/client/src/constants/index.js
+++ b/client/src/constants/index.js
@@ -24,7 +24,7 @@ export const navlinks = [
   {
     name: 'LOGOUT',
     imgUrl: logout,
-    link: '/',
+    link: '/home',
     disabled: false,
   },
 ];


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Fixing the Wrong page redirection Bug when clicking log-out button

## Proposed Changes
- Changed the `/` to `/home` for the `Logout` button
- Here using the `/home` instead of `/` will ensure to navigate the user to `Let's Start` page, This is simply because the user is not log in to view the home section.
- The bug has been fixed using these steps.

## Check List (Check all the applicable boxes)

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] Bug(s) fixed
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
