### PR TITLE
feat: add pr author auto assign workflow 🤖

### DIFF
--- a/.github/workflows/author-assign.yml
+++ b/.github/workflows/author-assign.yml
@@ -1,0 +1,13 @@
+name: 'Author Assign'
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toshimaru/auto-author-assign@v1.6.2
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
## Close #180 

## Proposed Changes
- Added Github Workflow which assigns the PR to author when it's created or reopened.

## Check List (Check all the applicable boxes)

- [x] New Feature(s) added
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
